### PR TITLE
Support EventMachine 1.0.4+ or EventMachine-LE

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@ Provides `Thin::Backends::AttachSocket` for booting a thin server on an already 
 Socket.
 
 This is useful when running thin inside [einhorn](https://github.com/stripe/einhorn), and
-it requires [eventmachine-le](https://github.com/ibc/EventMachine-LE).
+it requires either a recent [eventmachine](https://github.com/eventmachine/eventmachine) gem
+(1.0.4 and up implement the required functions), or
+[eventmachine-le](https://github.com/ibc/EventMachine-LE).
 
 Installation
 ============
 
 Either `gem install thin-attach_socket`, or add `gem 'thin-attach_socket'` to your
-`Gemfile` and run `bundle`.
+`Gemfile`, and run `bundle`.
 
 Usage
 =====
@@ -46,4 +48,3 @@ thin-attach_socket is released under the Ruby License, http://www.ruby-lang.org/
 
 It was heavily based on the [work](https://github.com/stripe/thin/commit/42e29ba23a136a30dc11a1c9dff1fe1187dc9eee) of
 Patrick Collison at Stripe.
-

--- a/lib/thin/attach_socket.rb
+++ b/lib/thin/attach_socket.rb
@@ -1,3 +1,10 @@
+require 'eventmachine'
+
+# Sanity-check that our EventMachine has the required methods:
+unless EventMachine.respond_to?(:attach_server)
+  raise "You need an EventMachine that supports .attach_server. That can be EventMachine-LE or EventMachine 1.0.4 and above."
+end
+
 # Based on Patrick Collison's commit to stripe/thin:
 # https://github.com/stripe/thin/commit/42e29ba23a136a30dc11a1c9dff1fe1187dc9eee
 #

--- a/thin-attach_socket.gemspec
+++ b/thin-attach_socket.gemspec
@@ -6,9 +6,10 @@ Gem::Specification.new do |s|
   s.email = "conrad.irwin@gmail.com"
   s.homepage = "http://github.com/ConradIrwin/thin-attach_socket"
   s.summary = "Provides Thin::Backends::AttachServer for booting thin on an existing socket."
-  s.description = "This is useful for running thin behind einhorn, and requires eventmachine-le"
+  s.description = "This is useful for running thin behind einhorn, and requires a recent eventmachine"
   s.files = `git ls-files`.split("\n")
   s.require_path = "lib"
   s.add_dependency 'thin'
-  s.add_dependency 'eventmachine-le'
+
+  s.requirements << 'eventmachine >= 1.0.4 or eventmachine-le'
 end


### PR DESCRIPTION
Vanilla EventMachine 1.0.4 and above now support `attach_server`, so I think this gem should support it. Sadly, there's no good way in Rubygems specs to express a requirement on two different, and differently-versioned gems that do the ~same thing, so I believe this may be the next best thing /-:

Hope this is good, happy to make revisions if not (:
